### PR TITLE
add support for top-level custom zarr extensions using json schema references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,7 @@ dependencies = [
     'typing_extensions==4.9.*',
     'donfig==0.8.*',
     'obstore==0.5.*',
+    'jsonschema==4.24.*",
     # test deps
     'zarr[test]',
     'zarr[remote_tests]',

--- a/src/zarr/core/extensions.py
+++ b/src/zarr/core/extensions.py
@@ -1,0 +1,40 @@
+import json
+import functools
+from urllib.parse import urlparse
+import urllib3
+
+import jsonschema
+
+def _is_url(url: str) -> bool:
+    """Checks whether the input string is a valid URL.
+
+    Args:
+        url (str): The string to check.
+
+    Returns:
+        bool: True if the input string is a valid URL, False otherwise.
+    """
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
+
+
+@functools.lru_cache()
+def _fetch_remote_schema(input_path: str):
+    if _is_url(input_path):
+        resp = urllib3.request("GET", input_path)
+        data = resp.json()
+    else:
+        with open(input_path) as f:
+            data = json.load(f)
+    return data
+
+
+def validate_extension(extension_data: dict, schema_ref: str) -> str:
+    """Validates the extension against the remote JSON schema, returning the top-level
+    key to where the schema is stored in the node."""
+    schema = _fetch_remote_schema(schema_ref)
+    jsonschema.validate(extension_data, schema)
+    return schema['required'][0]

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -431,7 +431,7 @@ class GroupMetadata(Metadata):
         if self.consolidated_metadata:
             result["consolidated_metadata"] = self.consolidated_metadata.to_dict()
 
-        for (name, extension) in self.extensions.items():
+        for (name, extension) in result.pop('extensions').items():
             result[name] = extension
 
         return result

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -48,6 +48,7 @@ from zarr.core.common import (
     parse_shapelike,
 )
 from zarr.core.config import config
+from zarr.core.extensions import validate_extension
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.sync import SyncMixin, sync
 from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataValidationError
@@ -329,6 +330,11 @@ class GroupMetadata(Metadata):
     zarr_format: ZarrFormat = 3
     consolidated_metadata: ConsolidatedMetadata | None = None
     node_type: Literal["group"] = field(default="group", init=False)
+    extension_schemas: list[str] = field(default_factory=list)
+
+    # A logical abstraction to hold all extensions referenced by the group.
+    # Extensions are physically stored under top-level keys of the group.
+    extensions: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     def to_buffer_dict(self, prototype: BufferPrototype) -> dict[str, Buffer]:
         json_indent = config.get("json_indent")
@@ -383,6 +389,8 @@ class GroupMetadata(Metadata):
         attributes: dict[str, Any] | None = None,
         zarr_format: ZarrFormat = 3,
         consolidated_metadata: ConsolidatedMetadata | None = None,
+        extension_schemas: list[str] | None = None,
+        extensions: dict[str, dict[str, Any]] | None = None
     ) -> None:
         attributes_parsed = parse_attributes(attributes)
         zarr_format_parsed = parse_zarr_format(zarr_format)
@@ -390,6 +398,8 @@ class GroupMetadata(Metadata):
         object.__setattr__(self, "attributes", attributes_parsed)
         object.__setattr__(self, "zarr_format", zarr_format_parsed)
         object.__setattr__(self, "consolidated_metadata", consolidated_metadata)
+        object.__setattr__(self, "extension_schemas", extension_schemas)
+        object.__setattr__(self, "extensions", extensions)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> GroupMetadata:
@@ -407,12 +417,23 @@ class GroupMetadata(Metadata):
             expected = {x.name for x in fields(cls)}
             data = {k: v for k, v in data.items() if k in expected}
 
-        return cls(**data)
+        # Parse extensions
+        extensions = {}
+        for schema_ref in data.get("extension_schemas", []):
+            schema_key = validate_extension(data, schema_ref)
+            extension_data = data.pop(schema_key)
+            extensions.update({schema_key: extension_data})
+
+        return cls(**data, extensions=extensions)
 
     def to_dict(self) -> dict[str, Any]:
         result = asdict(replace(self, consolidated_metadata=None))
         if self.consolidated_metadata:
             result["consolidated_metadata"] = self.consolidated_metadata.to_dict()
+
+        for (name, extension) in self.extensions.items():
+            result[name] = extension
+
         return result
 
 


### PR DESCRIPTION
The goal of this PR is to provide an example of how `python-zarr` could be extended to support custom extensions.  This PR is not complete, the intent is to inform discussion around ZEP10.  There are several high level goals:
1. Don't make any breaking changes to the existing Zarr spec, which means extensions should be stored at the top-level of each node.
2. Follow STAC's implementation of extensions, which includes a top level key linking to an array of remote JSON Schema references which validate the extensions present in the node.
3. Provide a consistent mechanism that works similarly across "custom" extensions and "official" extensions (ex. `chunk_grid`, `data_type`).
4. Align with the `zarr-python` approach of modeling each node as a class.

This PR proposes the addition of the `extension_schemas` key to the Zarr v3 spec.  This is a physical key that may be present on any node type and contains an array of JSON Schemas indicating what extensions are present in the node.  Similar to `stac_extensions` in the STAC spec.

It also proposes the addition of a **logical** `extensions` key to `zarr-python` which contains all extensions implemented by the node, allowing `zarr-python` to provide consistent access patterns to both custom and official Zarr extensions.  


```python
from zarr.core.group import GroupMetadata

group_metadata = {
    "attributes": {},
    "zarr_format": 3,
    "consolidated_metadata": None,
    "node_type": "group",
    # A list of JSON schemas, one for each extension implemented by the node
    "extension_schemas": [
        "https://raw.githubusercontent.com/geospatial-jeff/cog2zarr/refs/heads/pydantic-zarr/jsonschemas/gdal.json"
    ],
    # Top-level extensions
    "geo": {
        "name": "gdal",
        "configuration": {
        "band_names": [
            "red",
            "green",
            "blue",
            "nir"
        ],
        "group_configuration": "chunky",
        "transform": [
            499980.0,
            10.0,
            0.0,
            5400000.0,
            0.0,
            -10.0
        ],
        "epsg": "EPSG:32633",
        "wkt": "PROJCS[\"WGS 84 / UTM zone 33N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",15],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32633\"]]",
        "projjson": "{\"$schema\":\"https://proj.org/schemas/v0.7/projjson.schema.json\",\"type\":\"ProjectedCRS\",\"name\":\"WGS 84 / UTM zone 33N\",\"base_crs\":{\"name\":\"WGS 84\",\"datum\":{\"type\":\"GeodeticReferenceFrame\",\"name\":\"World Geodetic System 1984\",\"ellipsoid\":{\"name\":\"WGS 84\",\"semi_major_axis\":6378137,\"inverse_flattening\":298.257223563}},\"coordinate_system\":{\"subtype\":\"ellipsoidal\",\"axis\":[{\"name\":\"Geodetic latitude\",\"abbreviation\":\"Lat\",\"direction\":\"north\",\"unit\":\"degree\"},{\"name\":\"Geodetic longitude\",\"abbreviation\":\"Lon\",\"direction\":\"east\",\"unit\":\"degree\"}]},\"id\":{\"authority\":\"EPSG\",\"code\":4326}},\"conversion\":{\"name\":\"UTM zone 33N\",\"method\":{\"name\":\"Transverse Mercator\",\"id\":{\"authority\":\"EPSG\",\"code\":9807}},\"parameters\":[{\"name\":\"Latitude of natural origin\",\"value\":0,\"unit\":\"degree\",\"id\":{\"authority\":\"EPSG\",\"code\":8801}},{\"name\":\"Longitude of natural origin\",\"value\":15,\"unit\":\"degree\",\"id\":{\"authority\":\"EPSG\",\"code\":8802}},{\"name\":\"Scale factor at natural origin\",\"value\":0.9996,\"unit\":\"unity\",\"id\":{\"authority\":\"EPSG\",\"code\":8805}},{\"name\":\"False easting\",\"value\":500000,\"unit\":\"metre\",\"id\":{\"authority\":\"EPSG\",\"code\":8806}},{\"name\":\"False northing\",\"value\":0,\"unit\":\"metre\",\"id\":{\"authority\":\"EPSG\",\"code\":8807}}]},\"coordinate_system\":{\"subtype\":\"Cartesian\",\"axis\":[{\"name\":\"Easting\",\"abbreviation\":\"\",\"direction\":\"east\",\"unit\":\"metre\"},{\"name\":\"Northing\",\"abbreviation\":\"\",\"direction\":\"north\",\"unit\":\"metre\"}]},\"id\":{\"authority\":\"EPSG\",\"code\":32633}}"
        }
    }
}
md = GroupMetadata.from_dict(group_metadata)
assert "geo" in md.extensions
d = md.to_dict()
assert "geo" in d
assert d == group_metadata
```

I have no yet updated `ArrayMetadata` to support this, however I think it's fairly clear how that would work.  The only difference is the array node type currently implements several official Zarr extensions which would be rolled into the logical `extensions` member for consistent access alongside any other custom extensions.

Importantly, this PR doesn't update `zarr-python` to **do anything** with these custom extensions besides parsing / validating them.  Whether or not a reader such as `zarr-python` does anything with an extension is based on extension maturity, target audience etc.